### PR TITLE
[cosmeticts / trademark-conformity] Project rename part 2

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
- You may use, distribute and copy XWMM under the terms of GNU General
+ You may use, distribute and copy WIMM under the terms of GNU General
  Public License version 2 or any later version, which is displayed below.
 
 -------------------------------------------------------------------------

--- a/addon.xml
+++ b/addon.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
-  id="webinterface.WiMM"
+  id="webinterface.WIMM"
   version="4.1.8"
-  name="WiMM"
+  name="WIMM"
   provider-name="slash | Zernable | MokuJinJin | nwtn | fyfe | criticalfiction">
   <requires>
     <import addon="xbmc.json" version="6.16.0"/>
@@ -11,7 +11,7 @@
     point="xbmc.gui.webinterface"/>
   <extension point="xbmc.addon.metadata">
     <summary>Web Interface to manage media library for kodi.</summary>
-    <description>WiMM allows you to customize and change metadata for movies, tvshows and music from a standard browser</description>
+    <description>WIMM allows you to customize and change metadata for movies, tvshows and music from a standard browser</description>
     <platform>all</platform>
     <source>https://github.com/slash2009/XWMM</source>
     <forum>http://forum.kodi.tv/showthread.php?tid=188839</forum>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,12 @@
-WiMM Change log
+[B]WIMM Change log[/B]
 
 4.1.8
-- partial rename from XWMM to WiMM
+- Partial rename from XWMM to WIMM
+- Tab name fix
+- Copyright headers XWMM to WIMM
 - Bump json api to 6.16.0 (Kodi Helix api version)
+
+[B]XWMM Change log[/B]
 
 4.1.7
 - Add option to scan/clean the library (Issue #100)

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>Web interface Media Manager</title>
+    <title>Web Interface Media Manager (WIMM)</title>
 
     <meta charset="utf-8">
     <meta http-equiv="cache-control" content="no-cache">

--- a/resources/css/htmlexport.css
+++ b/resources/css/htmlexport.css
@@ -1,20 +1,20 @@
 /*
  * Copyright 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 body {

--- a/resources/js/app/common/audio.js
+++ b/resources/js/app/common/audio.js
@@ -2,20 +2,20 @@
 /*
  * Copyright 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 Ext.ns('XWMM.audio');

--- a/resources/js/app/common/ext.ux.xbmc.js
+++ b/resources/js/app/common/ext.ux.xbmc.js
@@ -4,20 +4,20 @@
  * Copyright 2013 nwtn.
  * Copyright 2013, 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 function xbmcJsonRPC(params) {

--- a/resources/js/app/common/genre.js
+++ b/resources/js/app/common/genre.js
@@ -4,20 +4,20 @@
  * Copyright 2013 uNiversal.
  * Copyright 2013, 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 Ext.ns('XWMM.video');

--- a/resources/js/app/common/global.js
+++ b/resources/js/app/common/global.js
@@ -6,20 +6,20 @@
  * Copyright 2013, 2014 Andrew Fyfe.
  * Copyright 2014 criticalfiction.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 var myVersion = '4.1.8';

--- a/resources/js/app/common/images.js
+++ b/resources/js/app/common/images.js
@@ -3,20 +3,20 @@
  * Copyright 2013 uNiversal.
  * Copyright 2013, 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 var coverTpl = new Ext.XTemplate(

--- a/resources/js/app/common/util.js
+++ b/resources/js/app/common/util.js
@@ -5,20 +5,20 @@
  * Copyright 2013 uNiversal.
  * Copyright 2013, 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 Ext.ns('XWMM.util');

--- a/resources/js/app/common/video.js
+++ b/resources/js/app/common/video.js
@@ -2,20 +2,20 @@
 /*
  * Copyright 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 Ext.ns('XWMM.video');

--- a/resources/js/app/common/xbmc.js
+++ b/resources/js/app/common/xbmc.js
@@ -6,20 +6,20 @@
  * Copyright 2013, 2014 Andrew Fyfe.
  * Copyright 2014 criticalfiction.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 /**

--- a/resources/js/app/movies/app.js
+++ b/resources/js/app/movies/app.js
@@ -4,20 +4,20 @@
  * Copyright 2013 uNiversal.
  * Copyright 2013, 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 Ext.onReady(function() {

--- a/resources/js/app/movies/htmlexport.js
+++ b/resources/js/app/movies/htmlexport.js
@@ -4,20 +4,20 @@
  * Copyright 2013 uNiversal.
  * Copyright 2013, 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 (function() {

--- a/resources/js/app/movies/include.js
+++ b/resources/js/app/movies/include.js
@@ -6,20 +6,20 @@
  * Copyright 2013, 2014 Andrew Fyfe.
  * Copyright 2014 criticalfiction.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 function setWatched() {

--- a/resources/js/app/movies/movie.js
+++ b/resources/js/app/movies/movie.js
@@ -4,20 +4,20 @@
  * Copyright 2013 uNiversal.
  * Copyright 2013, 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 // -----------------------------------------

--- a/resources/js/app/movies/moviegenre.js
+++ b/resources/js/app/movies/moviegenre.js
@@ -4,20 +4,20 @@
  * Copyright 2013 uNiversal.
  * Copyright 2013, 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 var MovieRecord = Ext.data.Record.create([

--- a/resources/js/app/movies/movielist.js
+++ b/resources/js/app/movies/movielist.js
@@ -5,20 +5,20 @@
  * Copyright 2013 nwtn.
  * Copyright 2013, 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 var MovieRecord = Ext.data.Record.create([

--- a/resources/js/app/movies/movierecent.js
+++ b/resources/js/app/movies/movierecent.js
@@ -4,20 +4,20 @@
  * Copyright 2013 uNiversal.
  * Copyright 2013, 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 var MovieRecord = Ext.data.Record.create([

--- a/resources/js/app/movies/movieset.js
+++ b/resources/js/app/movies/movieset.js
@@ -5,20 +5,20 @@
  * Copyright 2013 uNiversal.
  * Copyright 2013, 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 Ext.ns('XWMM.video');

--- a/resources/js/app/music/albumgenres.js
+++ b/resources/js/app/music/albumgenres.js
@@ -4,20 +4,20 @@
  * Copyright 2013 uNiversal.
  * Copyright 2013, 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 var AlbumcolModel = new Ext.grid.ColumnModel([

--- a/resources/js/app/music/artistalbum.js
+++ b/resources/js/app/music/artistalbum.js
@@ -4,20 +4,20 @@
  * Copyright 2013 uNiversal.
  * Copyright 2013, 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 var AlbumRecord = Ext.data.Record.create([

--- a/resources/js/app/music/genre.js
+++ b/resources/js/app/music/genre.js
@@ -4,20 +4,20 @@
  * Copyright 2013 uNiversal.
  * Copyright 2013, 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 var genreRecord = Ext.data.Record.create([

--- a/resources/js/app/music/images.js
+++ b/resources/js/app/music/images.js
@@ -2,20 +2,20 @@
  * Copyright 2011 slash2009.
  * Copyright 2013, 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 var coverTpl = new Ext.XTemplate(

--- a/resources/js/app/music/include.js
+++ b/resources/js/app/music/include.js
@@ -4,20 +4,20 @@
  * Copyright 2013 uNiversal.
  * Copyright 2013, 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 // -----------------------------------------

--- a/resources/js/app/music/music.js
+++ b/resources/js/app/music/music.js
@@ -4,20 +4,20 @@
  * Copyright 2013 uNiversal.
  * Copyright 2013, 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 // -----------------------------------------

--- a/resources/js/app/music/musiclist.js
+++ b/resources/js/app/music/musiclist.js
@@ -4,20 +4,20 @@
  * Copyright 2013 uNiversal.
  * Copyright 2013, 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 // -----------------------------------------

--- a/resources/js/app/music/yearalbum.js
+++ b/resources/js/app/music/yearalbum.js
@@ -4,20 +4,20 @@
  * Copyright 2013 uNiversal.
  * Copyright 2013, 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 var AlbumRecord = Ext.data.Record.create([

--- a/resources/js/app/tvshows/app.js
+++ b/resources/js/app/tvshows/app.js
@@ -4,20 +4,20 @@
  * Copyright 2013 uNiversal.
  * Copyright 2013, 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 Ext.onReady(function() {

--- a/resources/js/app/tvshows/include.js
+++ b/resources/js/app/tvshows/include.js
@@ -4,20 +4,20 @@
  * Copyright 2013 uNiversal.
  * Copyright 2013, 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 function setWatched() {

--- a/resources/js/app/tvshows/tvshow.js
+++ b/resources/js/app/tvshows/tvshow.js
@@ -4,20 +4,20 @@
  * Copyright 2013 uNiversal.
  * Copyright 2013, 2014 Andrew Fyfe.
  *
- * This file is part of XBMC Web Media Manager (XWMM).
+ * This file is part of Web interface Media Manager (WIMM) for kodi.
  *
- * XWMM is free software: you can redistribute it and/or modify
+ * WIMM is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
  *
- * XWMM is distributed in the hope that it will be useful,
+ * WIMM is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with XWMM.  If not, see <http://www.gnu.org/licenses/>.
+ * along with WIMM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 Ext.ns('TVShow');

--- a/view/movies-by-date-added.html
+++ b/view/movies-by-date-added.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>XWMM Movies</title>
+    <title>WIMM Movies</title>
 
     <meta charset="utf-8">
     <meta http-equiv="cache-control" content="no-cache">

--- a/view/movies-by-genre.html
+++ b/view/movies-by-genre.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>XWMM Movies</title>
+    <title>WIMM Movies</title>
 
     <meta charset="utf-8">
     <meta http-equiv="cache-control" content="no-cache">

--- a/view/movies.html
+++ b/view/movies.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>XWMM Movies</title>
+    <title>WIMM Movies</title>
 
     <meta charset="utf-8">
     <meta http-equiv="cache-control" content="no-cache">

--- a/view/music-by-artist.html
+++ b/view/music-by-artist.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>XWMM Music Management</title>
+    <title>WIMM Music Management</title>
     <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
     <link rel="shortcut icon" href="../resources/images/favicon.ico" />
     <link rel="stylesheet" type="text/css" href="../resources/js/extjs/resources/css/ext-all.css" />

--- a/view/music-by-genre.html
+++ b/view/music-by-genre.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>XWMM Music Management</title>
+    <title>WIMM Music Management</title>
     <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
     <link rel="shortcut icon" href="../resources/images/favicon.ico" />
     <link rel="stylesheet" type="text/css" href="../resources/js/extjs/resources/css/ext-all.css" />

--- a/view/music-by-year.html
+++ b/view/music-by-year.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>XWMM Music Management</title>
+    <title>WIMM Music Management</title>
     <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
     <link rel="shortcut icon" href="../resources/images/favicon.ico" />
     <link rel="stylesheet" type="text/css" href="../resources/js/extjs/resources/css/ext-all.css" />

--- a/view/tv-shows.html
+++ b/view/tv-shows.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>XWMM TV Shows</title>
+    <title>WiMM TV Shows</title>
 
     <meta charset="utf-8">
     <meta http-equiv="cache-control" content="no-cache">


### PR DESCRIPTION
Decided to do this as a PR for two reasons.

1) All developers or people involved with XWMM/WiMM can see what changes are being made and what's still missing (code)
2) To also show @slash2009 how the project should be renamed and also the project description see note

For 2) see https://github.com/uNiversaI/WiMM please note its not _XWMM_ but _WiMM_ and most importantly
The project description must be changed to **_Web interface Media Manager (_WiMM*) for Kodi***
- Note **_The project description is conformity to trademark policy for XBMC Foundation.**_

There are loads of XBMC named files/functions and XWMM hard-coded stuffs, Im not doing any of those because really dont want to break anything.

@fyfe @nwtn @slash2009 @criticalfiction 

Will mark this as approved and if no one has anything to say will merge in a few days.

All other changes in 2) require @slash2009 since we have no access to do those.
